### PR TITLE
add censored log normal vignette

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "methods/ds-toolbox-notebook-EEX-placebased-exposure"]
 	path = methods/ds-toolbox-notebook-EEX-placebased-exposure
 	url = https://github.com/NERC-CEH/ds-toolbox-notebook-EEX-placebased-exposure.git
+[submodule "methods/ds-toolbox-notebook-clognorm-mgcv"]
+	path = methods/ds-toolbox-notebook-clognorm-mgcv
+	url = git@github.com:NERC-CEH/ds-toolbox-notebook-clognorm-mgcv.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -24,4 +24,4 @@
 	url = https://github.com/NERC-CEH/ds-toolbox-notebook-EEX-placebased-exposure.git
 [submodule "methods/ds-toolbox-notebook-clognorm-mgcv"]
 	path = methods/ds-toolbox-notebook-clognorm-mgcv
-	url = git@github.com:NERC-CEH/ds-toolbox-notebook-clognorm-mgcv.git
+	url = https://github.com/NERC-CEH/ds-toolbox-notebook-clognorm-mgcv.git

--- a/_toc.yml
+++ b/_toc.yml
@@ -26,4 +26,5 @@ parts:
     file: methods/ds-toolbox-notebook-metals_EEX_demo/metals_EEX_demo.ipynb
   - title: Exploration of chemical pollution from a place based perspective  
     file: methods/ds-toolbox-notebook-EEX-placebased-exposure/EEX-placebased-exposure.ipynb
-
+  - title: Censored log-normal generalized additive modelling
+    file: methods/ds-toolbox-notebook-clognorm-mgcv/clognorm-book.ipynb


### PR DESCRIPTION
This is part of the UKCEH contract with the Environment Agency RDE 945.

**The following changes are made:**
- add notebook for censored log normal modelling in `mgcv`

I followed the `CONTRIBUTING.md` instructions so hopefully this all works, but apologies if I missed anything.