### PR TITLE
Jez/redirect

### DIFF
--- a/.github/redirects.json
+++ b/.github/redirects.json
@@ -1,0 +1,9 @@
+{
+  "redirects": [
+    {
+      "from": "intro.html",
+      "to": "/data-science-toolbox/",
+      "canonical": "https://nerc-ceh.github.io/data-science-toolbox/"
+    }
+  ]
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,9 @@
 name: Jupyter Book (via myst) GitHub Pages Deploy
 on:
   push:
-    # Runs on pushes targeting the default branch
+    # Runs on pushes targeting the default branch or the redirect-test branch
+    branches: [main, jez/redirect]
+  pull_request:
     branches: [main]
 env:
   # `BASE_URL` determines, relative to the root of the domain, the URL that your site is served from.
@@ -41,10 +43,17 @@ jobs:
         run: npm install -g jupyter-book
       - name: Build HTML Assets
         run: jupyter-book build --html
+      - name: Add legacy redirects
+        run: python scripts/add_redirects.py ./_build/html
+      - name: Verify legacy redirects
+        run: |
+          test -f ./_build/html/intro.html
+          grep -q "/data-science-toolbox/" ./_build/html/intro.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: './_build/html'
       - name: Deploy to GitHub Pages
         id: deployment
+        if: github.ref == 'refs/heads/main'
         uses: actions/deploy-pages@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,7 @@ concurrency:
   group: 'pages'
   cancel-in-progress: false
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,7 +50,15 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: './_build/html'
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        if: github.ref == 'refs/heads/main'
         uses: actions/deploy-pages@v4

--- a/scripts/add_redirects.py
+++ b/scripts/add_redirects.py
@@ -1,0 +1,52 @@
+"""Write HTML redirect pages into the build directory based on .github/redirects.json."""
+
+import json
+import pathlib
+import sys
+
+REDIRECTS_FILE = pathlib.Path(".github/redirects.json")
+
+REDIRECT_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting...</title>
+  <meta http-equiv="refresh" content="0; url={to}">
+  <link rel="canonical" href="{canonical}">
+  <script>window.location.replace("{to}");</script>
+</head>
+<body>
+  <p>This page has moved. <a href="{to}">Click here if you are not redirected.</a></p>
+</body>
+</html>
+"""
+
+
+def load_redirects():
+    if not REDIRECTS_FILE.exists():
+        sys.exit(f"Error: redirects file not found: {REDIRECTS_FILE}")
+    try:
+        data = json.loads(REDIRECTS_FILE.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        sys.exit(f"Error: invalid JSON in {REDIRECTS_FILE}: {exc}")
+    if "redirects" not in data or not isinstance(data["redirects"], list):
+        sys.exit(f"Error: {REDIRECTS_FILE} must contain a top-level 'redirects' list")
+    return data["redirects"]
+
+
+def main():
+    build_dir = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else pathlib.Path("_build/html")
+
+    for entry in load_redirects():
+        dest = build_dir / entry["from"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(
+            REDIRECT_TEMPLATE.format(to=entry["to"], canonical=entry["canonical"]),
+            encoding="utf-8",
+        )
+        print(f"Created redirect: {entry['from']} -> {entry['to']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request resolves issue: #75 

**The following changes are made:**
Add legacy redirect support for intro.html . Adds a redirect from the legacy URL /data-science-toolbox/intro.html to /data-science-toolbox/ so that any existing links or bookmarks to the old intro page continue to work after the Jupyter Book v2 migration.

- .github/redirects.json — config file defining redirect mappings (from, to URL)
- scripts/add_redirects.py — stdlib-only Python script that reads the config and writes HTML redirect pages into the build directory
- .github/workflows/publish.yml — adds Add legacy redirects and Verify legacy redirects steps after the build; splits the single job into build and deploy so the github-pages environment protection rule is not triggered on non-main branches
Testing:

CI ran on jez/redirect — build, redirect generation, and verify steps all passed
Artifact downloaded and inspected to confirm intro.html contains the correct target URL