### PR TITLE
Include initial template form for including notebook

### DIFF
--- a/.github/ISSUE_TEMPLATE/notebook_inclusion_request.yml
+++ b/.github/ISSUE_TEMPLATE/notebook_inclusion_request.yml
@@ -35,7 +35,7 @@ body:
     id: repository_details
     attributes:
       label: Repository Details
-      description: In the format below provide the relevant details about where the notebook is stored.
+      description: In the format below provide the relevant details about your repository and where the notebook and its assets are stored within it.
       value: |
         notebooks:
         - name: ds-toolbox-notebook-name

--- a/.github/ISSUE_TEMPLATE/notebook_inclusion_request.yml
+++ b/.github/ISSUE_TEMPLATE/notebook_inclusion_request.yml
@@ -1,0 +1,79 @@
+name: Notebook Inclusion Request
+description: Submit a completed notebook for review and inclusion.
+title: "Including notebook on ..."
+labels:
+  - notebook-inclusion
+assignees:
+  - Jez-Carter
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to highlight a notebook for inclusion into the data science toolbox.
+
+  - type: input
+    id: notebook_title
+    attributes:
+      label: Notebook Title
+    validations:
+      required: true
+      
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary of Notebook/Method
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Additional Details
+
+        Use this section to provide required additional info (datasets, reproducibility notes, links). This can be done iteratively, and the notebook will be reviewed once all required information is provided.
+
+  - type: textarea
+    id: repository_details
+    attributes:
+      label: Repository Details
+      description: In the format below provide the relevant details about where the notebook is stored.
+      value: |
+        notebooks:
+        - name: ds-toolbox-notebook-name
+          url: https://github.com/NERC-CEH/ds-toolbox-notebook-name.git
+          branch: main
+          path: notebook.ipynb
+          assets:
+            - images/
+
+  - type: textarea
+    id: keywords
+    attributes:
+      label: Key Concepts/Keywords
+      description: Terms that will aid discovery within the toolbox, e.g. Bayesian Inference, Climatology, etc.
+      value: |
+        - Example 1
+        - Example 2, etc.
+
+  - type: textarea
+    id: datasets
+    attributes:
+      label: Key Datasets
+      description: List the key datasets involved in the notebook, e.g. Automatic Weather Station Data (link)
+      value: |
+        - Example 1
+        - Example 2, etc.
+        
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist for Repository Readiness
+      description: Please confirm which of the following are completed.
+      options:
+        - label: Repository is publicly accessible
+        - label: Repository includes a licence
+        - label: Repository includes a README
+        - label: Repository includes a CITATION.cff file
+        - label: Dependencies are documented/environment file is provided
+        - label: Notebook executes successfully from start to finish
+        - label: Notebook allows interactive execution, e.g. via Binder or Colab
+      

--- a/.github/ISSUE_TEMPLATE/notebook_inclusion_request.yml
+++ b/.github/ISSUE_TEMPLATE/notebook_inclusion_request.yml
@@ -58,7 +58,7 @@ body:
     id: datasets
     attributes:
       label: Key Datasets
-      description: List the key datasets involved in the notebook, e.g. Automatic Weather Station Data (link)
+      description: List the key datasets involved in the notebook, indicate what the dataset access is and include links where possible e.g. Automatic Weather Station Data (freely available online - link)
       value: |
         - Example 1
         - Example 2, etc.

--- a/about_this_project/contributing_a_method.md
+++ b/about_this_project/contributing_a_method.md
@@ -7,7 +7,7 @@ The toolbox supports inclusion of a wide range of methods and different coding l
 The contribution process is very straightforward and requires only a few steps - so don't hold back and start the process as follows:
 
 ## 1. Open a GitHub issue
-Create a [GitHub issue in the repository](https://github.com/NERC-CEH/data-science-toolbox/issues) and add the '*notebook inclusion*' label. If struggling with any of the further stages, write a comment about it in your GitHub issue and tag the toolbox reviewers using: *\@NERC-CEH/toolbox-reviewers*.
+[Create a GitHub issue in the repository](https://github.com/NERC-CEH/data-science-toolbox/issues/new/choose) and select the '*Notebook Inclusion Request*' template. Fill in the initial fields. If you're able to fill in the additional fields section do that as well, although these can also be done subsequently after following the below steps. If struggling with any of the below steps, write a comment about it in your GitHub issue and tag the toolbox reviewers using: *\@NERC-CEH/toolbox-reviewers*.
 
 ## 2. Prepare your notebook
 Create a notebook utilising the structure in this [template](https://github.com/NERC-CEH/data-science-toolbox/blob/main/notebook_guidance/template_notebook.ipynb), which when rendered in the toolbox will look like this: [template rendered](https://nerc-ceh.github.io/data-science-toolbox/template-notebook). 


### PR DESCRIPTION
**This pull request partially addresses issue: #58**

**The following changes are made:**
- Inclusion of initial basic issue template for including a notebook: `.github/ISSUE_TEMPLATE/notebook_inclusion_request.yml`
- Update to contribution file to reference this issue template.

Further improvements to the issue template can be made based off this initial version.
